### PR TITLE
Fix OnReconnected example (said OnReconnecting)

### DIFF
--- a/docs/4.SignalR/2.GeneralEvents.md
+++ b/docs/4.SignalR/2.GeneralEvents.md
@@ -28,7 +28,7 @@ signalRConnection.OnReconnecting += (con) => Debug.Log("Reconnecting");
 - **OnReconnected**: Fired when a reconnect attempt was successful.
 
 ```language-csharp
-signalRConnection.OnReconnecting += (con) => Debug.Log("Reconnected");
+signalRConnection.OnReconnected += (con) => Debug.Log("Reconnected");
 ```
 
 - **OnStateChnaged**: Fired when the connection’s State changed. The event handler will receive both the old state and the new state.


### PR DESCRIPTION
Looks like the code was copied from the example before it but only the message was Debug.Log argument was changed.